### PR TITLE
Serialize report workflow pushes via concurrency group

### DIFF
--- a/.github/workflows/report-direct-ann-term.yml
+++ b/.github/workflows/report-direct-ann-term.yml
@@ -2,6 +2,10 @@ on:
   issues:
     types: [opened] # change to "locked"?
 
+concurrency:
+  group: commit-reports-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
 
   run-direct-report-on-issue:

--- a/.github/workflows/report-regulates-ann-term.yml
+++ b/.github/workflows/report-regulates-ann-term.yml
@@ -2,6 +2,10 @@ on:
   issues:
     types: [opened] # change to "locked"?
 
+concurrency:
+  group: commit-reports-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
 
   run-regulates-report-on-issue:

--- a/.github/workflows/report-term-usage.yml
+++ b/.github/workflows/report-term-usage.yml
@@ -2,6 +2,10 @@ on:
   issues:
     types: [opened]
 
+concurrency:
+  group: commit-reports-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
 
   run-term-usage-report:


### PR DESCRIPTION
Prevents concurrent runs on the same issue from racing on git push, which caused non-fast-forward rejections when multiple labels fired different workflows.